### PR TITLE
Add tasks to max project across channels or z-slices

### DIFF
--- a/merlin/analysis/decode.py
+++ b/merlin/analysis/decode.py
@@ -60,7 +60,7 @@ class Decode(BarcodeSavingParallelAnalysisTask):
                 self.parameters["z_duplicate_xy_pixel_threshold"] = np.sqrt(2)
 
         self.cropWidth = self.parameters["crop_width"]
-        self.imageSize = dataSet.get_image_dimensions()
+        self.imageSize = dataSet.imageDimensions
 
     def fragment_count(self):
         return len(self.dataSet.get_fovs())
@@ -106,7 +106,7 @@ class Decode(BarcodeSavingParallelAnalysisTask):
 
         zPositionCount = len(self.dataSet.get_z_positions())
         bitCount = codebook.get_bit_count()
-        imageShape = self.dataSet.get_image_dimensions()
+        imageShape = self.dataSet.imageDimensions
         decodedImages = np.zeros((zPositionCount, *imageShape), dtype=np.int16)
         magnitudeImages = np.zeros((zPositionCount, *imageShape), dtype=np.float32)
         distances = np.zeros((zPositionCount, *imageShape), dtype=np.float32)

--- a/merlin/analysis/generatemosaic.py
+++ b/merlin/analysis/generatemosaic.py
@@ -26,7 +26,7 @@ class GenerateMosaic(analysistask.AnalysisTask):
             self.parameters["draw_fov_labels"] = False
 
         if self.parameters["microns_per_pixel"] == "full_resolution":
-            self.mosaicMicronsPerPixel = self.dataSet.get_microns_per_pixel()
+            self.mosaicMicronsPerPixel = self.dataSet.micronsPerPixel
         else:
             self.mosaicMicronsPerPixel = self.parameters["microns_per_pixel"]
 

--- a/merlin/analysis/globalalign.py
+++ b/merlin/analysis/globalalign.py
@@ -131,7 +131,7 @@ class SimpleGlobalAlignment(GlobalAlignment):
 
     def fov_coordinates_to_global(self, fov, fovCoordinates):
         fovStart = self.dataSet.get_fov_offset(fov)
-        micronsPerPixel = self.dataSet.get_microns_per_pixel()
+        micronsPerPixel = self.dataSet.micronsPerPixel
         if len(fovCoordinates) == 2:
             return (
                 fovStart[0] + fovCoordinates[0] * micronsPerPixel,
@@ -185,7 +185,7 @@ class SimpleGlobalAlignment(GlobalAlignment):
         return pixels
 
     def fov_to_global_transform(self, fov):
-        micronsPerPixel = self.dataSet.get_microns_per_pixel()
+        micronsPerPixel = self.dataSet.micronsPerPixel
         globalStart = self.fov_coordinates_to_global(fov, (0, 0))
 
         return np.float32(
@@ -197,7 +197,7 @@ class SimpleGlobalAlignment(GlobalAlignment):
         )
 
     def get_global_extent(self):
-        fovSize = self.dataSet.get_image_dimensions()
+        fovSize = self.dataSet.imageDimensions
         fovBounds = [
             self.fov_coordinates_to_global(x, (0, 0)) for x in self.dataSet.get_fovs()
         ] + [
@@ -261,8 +261,8 @@ class CorrelationGlobalAlignment(GlobalAlignment):
     def _get_overlapping_regions(self, fov: int, minArea: int = 2000):
         """Get a list of all the fovs that overlap with the specified fov."""
         positions = self.dataSet.get_stage_positions()
-        pixelToMicron = self.dataSet.get_microns_per_pixel()
-        fovMicrons = [x * pixelToMicron for x in self.dataSet.get_image_dimensions()]
+        pixelToMicron = self.dataSet.micronsPerPixel
+        fovMicrons = [x * pixelToMicron for x in self.dataSet.imageDimensions]
         fovPosition = positions.loc[fov]
         overlapAreas = [
             i

--- a/merlin/analysis/maxproject.py
+++ b/merlin/analysis/maxproject.py
@@ -1,0 +1,167 @@
+import re
+from typing import List
+
+import numpy as np
+
+from merlin.core import analysistask
+
+
+class MaxProject(analysistask.ParallelAnalysisTask):
+    """An abstract class to max project a set of channel images into a new channel."""
+
+    def __init__(self, dataSet, parameters=None, analysisName=None) -> None:
+        super().__init__(dataSet, parameters, analysisName)
+        if "write_images" not in self.parameters:
+            self.parameters["write_images"] = False
+
+        self.write_images = self.parameters["write_images"]
+
+    @property
+    def z_positions(self) -> List[float]:
+        return self.dataSet.get_z_positions()
+
+    @property
+    def channels(self) -> np.ndarray:
+        return self.dataSet.get_data_organization().get_data_channels()
+
+    @property
+    def channel_names(self) -> np.ndarray:
+        return self.dataSet.get_data_organization().data["channelName"]
+
+    def _write_images(self, fov, images):
+        metadata = self.dataSet.analysis_tiff_description(
+            len(self.z_positions), len(self.channels)
+        )
+        with self.dataSet.writer_for_analysis_images(self, "max_projected", fov) as f:
+            for c in range(len(self.channels)):
+                for z in range(len(self.z_positions)):
+                    f.save(images[c, z], photometric="MINISBLACK", metadata=metadata)
+
+    def get_image(self, channel, fov, z):
+        """Get an image for a specific channel, fov, and z position."""
+        return self.dataSet.get_raw_image(
+            channel,
+            fov,
+            # TODO: make z_index_to_position internal to dataSet?
+            self.dataSet.z_index_to_position(z),
+        )
+
+    def get_images(self, fov: int) -> np.ndarray:
+        """Get a set of images for the specified fov.
+
+        Args:
+            fov: index of the field of view
+
+        Returns:
+            A 4-dimensional numpy array containing the images for the fov.
+            The images are arranged as [channel, z, x, y].
+        """
+        return np.array(
+            [
+                [self.get_image(c, fov, z) for z in self.z_positions]
+                for c in self.channels
+            ]
+        )
+
+    def _run_analysis(self, fov):
+        # This analysis task does not need computation
+        pass
+
+
+class MaxProjectFiducial(MaxProject):
+    """Max projects all z-slices of a set of fiducial images into a single image."""
+
+    def __init__(self, dataSet, parameters=None, analysisName=None) -> None:
+        super().__init__(dataSet, parameters, analysisName)
+
+    def fragment_count(self):
+        return len(self.dataSet.get_fovs())
+
+    def get_estimated_memory(self):
+        return 2048
+
+    def get_estimated_time(self):
+        return 5
+
+    def get_dependencies(self):
+        return []
+
+    def get_image(self, channel: int, fov: int, z: int) -> np.ndarray:
+        """Get an image for a specific channel, fov, and z position."""
+        return self.dataSet.get_fiducial_image(
+            channel,
+            fov,
+            # TODO: make z_index_to_position internal to dataSet?
+            self.dataSet.z_index_to_position(z),
+        )
+
+    def get_images(self, fov: int) -> np.ndarray:
+        images = super().get_images(fov)
+        projected = np.max(images, axis=1)
+        if self.write_images:
+            metadata = self.dataSet.analysis_tiff_description(1, len(self.channels))
+
+            with self.dataSet.writer_for_analysis_images(
+                self, "max_projected_fiducial_beads", fov
+            ) as f:
+                for channel in range(len(self.channels)):
+                    f.save(
+                        projected[channel], photometric="MINISBLACK", metadata=metadata
+                    )
+
+        return projected
+
+
+class MaxProjectBits(MaxProject):
+    """Combines all bit channels into a polyT channel."""
+
+    def __init__(self, dataSet, parameters=None, analysisName=None) -> None:
+        super().__init__(dataSet, parameters, analysisName)
+
+        if "channel_regex" not in self.parameters:
+            self.parameters["channel_regex"] = ""
+
+        self.channel_regex = self.parameters["channel_regex"]
+
+    def fragment_count(self):
+        return len(self.dataSet.get_fovs())
+
+    def get_estimated_memory(self):
+        return 2048
+
+    def get_estimated_time(self):
+        return 1
+
+    def get_dependencies(self):
+        return [self.parameters["warp_task"]]
+
+    def get_image(self, channel: int, fov: int, z: int) -> np.ndarray:
+        warp_task = self.dataSet.load_analysis_task(self.parameters["warp_task"])
+        z_index = self.dataSet.position_to_z_index(z)
+        return warp_task.get_aligned_image(fov, channel, z_index)
+
+    def get_images(self, fov: int) -> np.ndarray:
+        """Get the max projected bit images for the specified fov.
+
+        Args:
+            fov (int): index of the field of view
+
+        Returns:
+            np.ndarray: Image array of shape (z, x, y) with the projected bits.
+        """
+        images = super().get_images(fov)
+        print(self.channel_names)
+        print(re.match(self.channel_regex, self.channel_names.iloc[0]))
+        print(re.match(self.channel_regex, self.channel_names.iloc[-1]))
+        is_bit = np.array(
+            [re.match(self.channel_regex, name) for name in self.channel_names],
+            dtype=bool,
+        )
+        bit_images = images[is_bit]
+        projected = np.max(bit_images, axis=0)
+        if self.write_images:
+            metadata = self.dataSet.analysis_tiff_description(len(self.z_positions), 1)
+            with self.dataSet.writer_for_analysis_images(self, "polyT", fov) as f:
+                for z in range(len(self.z_positions)):
+                    f.save(projected[z], photometric="MINISBLACK", metadata=metadata)
+        return projected

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -11,9 +11,7 @@ from merlin.util import aberration, decoding, registration
 
 
 class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
-    """An analysis task for performing a single iteration of scale factor
-    optimization.
-    """
+    """Performs a single iteration of scale factor optimization."""
 
     def __init__(self, dataSet, parameters=None, analysisName=None) -> None:
         super().__init__(dataSet, parameters, analysisName)

--- a/merlin/analysis/segment.py
+++ b/merlin/analysis/segment.py
@@ -181,6 +181,10 @@ class CleanCellBoundaries(analysistask.ParallelAnalysisTask):
     def return_exported_data(self, fov: int) -> nx.Graph:
         return self.dataSet.load_graph_from_gpickle("cleaned_cells", self, fov)
 
+    # Wrapper so CleanCellBoundaries can be used as segment_task for PlotPerformance
+    def get_feature_database(self) -> spatialfeature.SpatialFeatureDB:
+        return self.segment_task.get_feature_database()
+
     def _run_analysis(self, fov: int) -> None:
         fovs = np.array(self.dataSet.get_fovs())
         boxes = self.align_task.get_fov_boxes()

--- a/merlin/analysis/slurmreport.py
+++ b/merlin/analysis/slurmreport.py
@@ -263,8 +263,8 @@ class SlurmReport(analysistask.AnalysisTask):
         self._plot_slurm_summary(reportDict)
 
         datasetMeta = {
-            "image_width": self.dataSet.get_image_dimensions()[0],
-            "image_height": self.dataSet.get_image_dimensions()[1],
+            "image_width": self.dataSet.imageDimensions[0],
+            "image_height": self.dataSet.imageDimensions[1],
             "barcode_length": self.dataSet.get_codebook(
                 self.parameters["codebook_index"]
             ).get_bit_count(),

--- a/merlin/analysis/warp.py
+++ b/merlin/analysis/warp.py
@@ -206,7 +206,11 @@ class FiducialCorrelationWarp(Warp):
         return 5
 
     def get_dependencies(self):
-        return []
+        return (
+            [self.parameters["fiducial_task"]]
+            if "fiducial_task" in self.parameters
+            else []
+        )
 
     def _filter(self, inputImage: np.ndarray) -> np.ndarray:
         highPassSigma = self.parameters["highpass_sigma"]
@@ -218,6 +222,14 @@ class FiducialCorrelationWarp(Warp):
             highPassSigma,
             borderType=cv2.BORDER_REPLICATE,
         )
+
+    def _get_fiducial_image(self, fov: int):
+        if "fiducial_task" in self.parameters:
+            fiducial_task = self.dataSet.load_analysis_task(
+                self.parameters["fiducial_task"]
+            )
+            return fiducial_task.get_image(fov)
+        return self.dataSet.get_fiducial_image(0, fov)
 
     def _run_analysis(self, fragmentIndex: int):
         # TODO - this can be more efficient since some images should

--- a/merlin/core/dataset.py
+++ b/merlin/core/dataset.py
@@ -1113,7 +1113,7 @@ class ImageDataSet(DataSet):
             tuple[int, int, int]: width, height, and n_frames of images
         """
         with imagereader.infer_reader(self.rawDataPortal.open_file(path)) as reader:
-            return reader.film_size()
+            return reader.size
 
     def _import_microscope_parameters(self, microscopeParametersName):
         sourcePath = os.sep.join(
@@ -1360,9 +1360,9 @@ class MERFISHDataSet(ImageDataSet):
         # TODO - this should be implemented using the position of the fov.
         return self.positions.loc[fov]["X"], self.positions.loc[fov]["Y"]
 
-    def z_index_to_position(self, zIndex: int) -> float:
+    def z_index_to_position(self, z: int) -> float:
         """Get the z position associated with the provided z index."""
-        return self.get_z_positions()[zIndex]
+        return self.get_z_positions()[z]
 
     def position_to_z_index(self, zPosition: float) -> int:
         """Get the z index associated with the specified z position.
@@ -1381,8 +1381,7 @@ class MERFISHDataSet(ImageDataSet):
     def get_z_positions(self) -> List[float]:
         """Get the z positions present in this dataset.
 
-        Returns
-        -------
+        Returns:
             A sorted list of all unique z positions
         """
         return self.dataOrganization.get_z_positions()

--- a/merlin/core/dataset.py
+++ b/merlin/core/dataset.py
@@ -1382,11 +1382,22 @@ class MERFISHDataSet(ImageDataSet):
             self.dataOrganization.get_image_frame_index(dataChannel, zPosition),
         )
 
-    def get_fiducial_image(self, dataChannel, fov):
-        return self.load_image(
-            self.dataOrganization.get_fiducial_filename(dataChannel, fov),
-            self.dataOrganization.get_fiducial_frame_index(dataChannel),
-        )
+    def get_fiducial_image(self, channel, fov, z=None) -> np.ndarray:
+        """Get the fiducial image for the specified channel, fov, and z-slice.
+
+        Args:
+            channel (_type_): Channel of image.
+            fov (_type_): Field of view of image.
+            z (int, optional): Z-slice within fiducial bead file of image.
+                Uses fiducialFrame from data organization .csv when not specified.
+
+        Returns:
+            np.ndarray with image of fiducial beads
+        """
+        if z is None:
+            z = self.dataOrganization.get_fiducial_frame_index(channel)
+        filename = self.dataOrganization.get_fiducial_filename(channel, fov)
+        return self.load_image(filename, z)
 
     def _import_positions_from_metadata(self):
         positionData = []

--- a/merlin/core/dataset.py
+++ b/merlin/core/dataset.py
@@ -1036,6 +1036,15 @@ class DataSet:
 
 
 class ImageDataSet(DataSet):
+    """
+    Attributes:
+        flipHorizontal (bool): Whether to flip the image horizontally when loading.
+        flipVertical (bool): Whether to flip the image vertically when loading.
+        transpose (bool): Whether to transpose the image when loading.
+        micronsPexPixel (float): Conversion factor to convert pixels to microns.
+        imageDimensions (tuple[int, int]): width and height of each image in pixels
+    """
+
     def __init__(
         self,
         dataDirectoryName: str,
@@ -1046,7 +1055,6 @@ class ImageDataSet(DataSet):
         """Create a dataset for the specified raw data.
 
         Args:
-        ----
             dataDirectoryName: the relative directory to the raw data
             dataHome: the base path to the data. The data is expected
                     to be in dataHome/dataDirectoryName. If dataHome

--- a/merlin/core/dataset.py
+++ b/merlin/core/dataset.py
@@ -1072,11 +1072,18 @@ class ImageDataSet(DataSet):
             self.rawDataPortal.list_files(extensionList=[".dax", ".tif", ".tiff"])
         )
 
-    def load_image(self, imagePath, frameIndex):
-        with imagereader.infer_reader(
-            self.rawDataPortal.open_file(imagePath)
-        ) as reader:
-            imageIn = reader.load_frame(int(frameIndex))
+    def load_image(self, path: str, frame: int) -> np.ndarray:
+        """Loads a frame from an image file.
+
+        Args:
+            path (str): Path to image.
+            frame (int): Frame within the image to load.
+
+        Returns:
+            np.ndarray: Image data for given frame.
+        """
+        with imagereader.infer_reader(self.rawDataPortal.open_file(path)) as reader:
+            imageIn = reader.load_frame(int(frame))
             if self.transpose:
                 imageIn = np.transpose(imageIn)
             if self.flipHorizontal:

--- a/merlin/core/dataset.py
+++ b/merlin/core/dataset.py
@@ -1123,19 +1123,6 @@ class ImageDataSet(DataSet):
             "image_dimensions", [2048, 2048]
         )
 
-    def get_microns_per_pixel(self):
-        """Get the conversion factor to convert pixels to microns."""
-        return self.micronsPerPixel
-
-    def get_image_dimensions(self):
-        """Get the dimensions of the images in this data set.
-
-        Returns
-        -------
-            A tuple containing the width and height of each image in pixels.
-        """
-        return self.imageDimensions
-
     def get_image_xml_metadata(self, imagePath: str) -> Dict:
         """Get the xml metadata stored for the specified image.
 

--- a/merlin/core/dataset.py
+++ b/merlin/core/dataset.py
@@ -1085,17 +1085,16 @@ class ImageDataSet(DataSet):
                 imageIn = np.flip(imageIn, axis=0)
             return imageIn
 
-    def image_stack_size(self, imagePath):
+    def image_stack_size(self, path: str) -> Tuple[int, int, int]:
         """Get the size of the image stack stored in the specified image path.
 
-        Returns
-        -------
-            a three element list with [width, height, frameCount] or None
-                    if the file does not exist
+        Args:
+            path (str): path to the image file
+
+        Returns:
+            tuple[int, int, int]: width, height, and n_frames of images
         """
-        with imagereader.infer_reader(
-            self.rawDataPortal.open_file(imagePath)
-        ) as reader:
+        with imagereader.infer_reader(self.rawDataPortal.open_file(path)) as reader:
             return reader.film_size()
 
     def _import_microscope_parameters(self, microscopeParametersName):

--- a/merlin/core/dataset.py
+++ b/merlin/core/dataset.py
@@ -245,6 +245,9 @@ class DataSet:
             imagej=imagej,
         )
 
+    # TODO: make slice vs. frame clearer
+    # believe that sliceCount is the number of z-slices in a stack
+    # and frameCount is the number of channels?
     @staticmethod
     def analysis_tiff_description(sliceCount: int, frameCount: int) -> Dict:
         imageDescription = {

--- a/merlin/data/dataorganization.py
+++ b/merlin/data/dataorganization.py
@@ -126,14 +126,17 @@ class DataOrganization:
         -------
             the index of the data channel where the data channel name is
                 dataChannelName
+
         Raises:
-            # TODO this should raise a meaningful exception if the data channel
-            # is not found
+            ValueError if the data channel is not found
         """
-        return self.data[
-            self.data["channelName"].apply(lambda x: str(x).lower())
-            == str(dataChannelName).lower()
-        ].index.values.tolist()[0]
+        channels = self.data["channelName"].apply(lambda x: str(x).lower())
+        channel = str(dataChannelName).lower()
+        try:
+            return self.data[channels == channel].index.values.tolist()[0]
+        except IndexError:
+            msg = f"{channel} not found among data channels {', '.join(channels)}."
+            raise ValueError(msg)
 
     def get_data_channel_color(self, dataChannel: int) -> str:
         """Get the color used for measuring the specified data channel.

--- a/merlin/merlin.py
+++ b/merlin/merlin.py
@@ -227,8 +227,8 @@ def run_with_snakemake(
             for t in dataSet.get_analysis_tasks()
         }
         datasetMeta = {
-            "image_width": dataSet.get_image_dimensions()[0],
-            "image_height": dataSet.get_image_dimensions()[1],
+            "image_width": dataSet.imageDimensions[0],
+            "image_height": dataSet.imageDimensions[1],
             "barcode_length": dataSet.get_codebook().get_bit_count(),
             "barcode_count": dataSet.get_codebook().get_barcode_count(),
             "fov_count": len(dataSet.get_fovs()),

--- a/merlin/plots/filterplots.py
+++ b/merlin/plots/filterplots.py
@@ -380,8 +380,8 @@ class FOVSpatialDistributionMetadata(PlotMetadata):
         self.filterTask = self._taskDict["filter_task"]
 
         dataSet = self._analysisTask.dataSet
-        self._width = dataSet.get_image_dimensions()[0]
-        self._height = dataSet.get_image_dimensions()[1]
+        self._width = dataSet.imageDimensions[0]
+        self._height = dataSet.imageDimensions[1]
         imageSize = max(self._height, self._width)
         self.radialBins = self._load_numpy_metadata(
             "radial_bins", np.arange(0, 0.5 * imageSize, (0.5 * imageSize) / 200)

--- a/merlin/util/imagereader.py
+++ b/merlin/util/imagereader.py
@@ -143,13 +143,13 @@ class Reader:
         """A (hopefully) unique string that identifies this movie."""
         return hashlib.md5(self.load_frame(0).tostring()).hexdigest()
 
-    def load_frame(self, frame_number):
-        assert (
-            frame_number >= 0
-        ), "Frame_number must be greater than or equal to 0, it is " + str(frame_number)
-        assert (
-            frame_number < self.number_frames
-        ), "Frame number must be less than " + str(self.number_frames)
+    def load_frame(self, frame: int):
+        assert frame >= 0, "frame must be greater than or equal to 0, it is " + str(
+            frame
+        )
+        assert frame < self.number_frames, "frame must be less than " + str(
+            self.number_frames
+        )
 
     def lock_target(self):
         """Returns the film focus lock target."""
@@ -225,11 +225,18 @@ class DaxReader(Reader):
             self.image_height = 256
             self.image_width = 256
 
-    def load_frame(self, frame_number):
-        """Load a frame & return it as a np array."""
-        super().load_frame(frame_number)
+    def load_frame(self, frame: int) -> np.ndarray:
+        """Load a frame & return it as a np array.
 
-        startByte = frame_number * self.image_height * self.image_width * 2
+        Args:
+            frame (int): Index of the frame to load.
+
+        Returns:
+            np.ndarray: A numpy array containing the frame image.
+        """
+        super().load_frame(frame)
+
+        startByte = frame * self.image_height * self.image_width * 2
         endByte = startByte + 2 * (self.image_height * self.image_width)
 
         dataFormat = np.dtype("uint16")
@@ -314,20 +321,20 @@ class TifReader(Reader):
                 )
             )
 
-    def load_frame(self, frame_number, cast_to_int16=True):
-        super().load_frame(frame_number)
+    def load_frame(self, frame: int, cast_to_int16: bool = True) -> np.ndarray:
+        super().load_frame(frame)
 
         # All the data is on a single page.
         if self.number_frames == self.frames_per_page:
             if self.number_frames == 1:
                 image_data = self.page_data
             else:
-                image_data = self.page_data[frame_number, :, :]
+                image_data = self.page_data[frame, :, :]
 
         # Multiple frames of data on multiple pages.
         elif self.frames_per_page > 1:
-            page = int(frame_number / self.frames_per_page)
-            frame = frame_number % self.frames_per_page
+            page = int(frame / self.frames_per_page)
+            frame = frame % self.frames_per_page
 
             # This is an optimization for files with a large number of frames
             # per page. In this case tifffile will keep loading the entire
@@ -346,7 +353,7 @@ class TifReader(Reader):
 
         # One frame on each page.
         else:
-            image_data = self.fileptr.asarray(key=frame_number)
+            image_data = self.fileptr.asarray(key=frame)
 
         assert len(image_data.shape) == 2, "Not a monochrome tif image! " + str(
             image_data.shape

--- a/merlin/util/imagereader.py
+++ b/merlin/util/imagereader.py
@@ -105,25 +105,22 @@ class Reader:
             self.fileptr.close()
             self.fileptr = None
 
-    def film_filename(self):
-        """Returns the film name."""
-        return self.filename
-
-    def film_size(self):
-        """Returns the film size."""
+    @property
+    def size(self):
+        """Returns the image size."""
         return [self.image_width, self.image_height, self.number_frames]
 
-    def film_location(self):
-        """Returns the picture x,y location, if available."""
-        if hasattr(self, "stage_x"):
+    @property
+    def location(self):
+        """Returns the image (x, y) location, if available."""
+        if hasattr(self, "stage_x") and hasattr(self, "stage_y"):
             return [self.stage_x, self.stage_y]
         else:
             return [0.0, 0.0]
 
-    def film_scale(self):
-        """Returns the scale used to display the film when
-        the picture was taken.
-        """
+    @property
+    def scale(self):
+        """Scale used to display the film when the image was taken."""
         if hasattr(self, "scalemin") and hasattr(self, "scalemax"):
             return [self.scalemin, self.scalemax]
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@
 select = ["E", "F", "I", "UP"]
 target-version = "py38"
 
+[tool.ruff.isort]
+known-first-party = ["merlin", "test"]
+
 [tool.pytest.ini_options]
 markers = [
     "slowtest: a test that takes longer than a couple seconds",

--- a/test/auxiliary_files/test_max_project.json
+++ b/test/auxiliary_files/test_max_project.json
@@ -1,0 +1,41 @@
+{
+    "analysis_tasks": [
+        {
+            "task": "MaxProjectFiducial",
+            "module": "merlin.analysis.maxproject",
+            "parameters": {
+                "write_images": true
+            }
+        },
+        {
+            "task": "FiducialCorrelationWarp",
+            "module": "merlin.analysis.warp",
+            "parameters": {
+                "write_aligned_images": true,
+                "fiducial_task": "MaxProjectFiducial"
+            }
+        },
+        {
+            "task": "SimpleGlobalAlignment",
+            "module": "merlin.analysis.globalalign"
+        },
+        {
+            "task": "MaxProjectBits",
+            "module": "merlin.analysis.maxproject",
+            "parameters": {
+                "channel_regex": "bit\\d+",
+                "write_images": true,
+                "warp_task": "FiducialCorrelationWarp"
+            }
+        },
+        {
+            "task": "WatershedSegment",
+            "module": "merlin.analysis.segment",
+            "parameters": {
+                "warp_task": "FiducialCorrelationWarp",
+                "global_align_task": "SimpleGlobalAlignment",
+                "watershed_channel_task": "MaxProjectBits"
+            }
+        }
+    ]
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,6 +22,22 @@ dataDirectory = os.sep.join([merlin.DATA_HOME, "test"])
 merfishDataDirectory = os.sep.join([merlin.DATA_HOME, "merfish_test"])
 
 
+def copy_test_files(folder):
+    to_copy = [
+        (merlin.DATA_ORGANIZATION_HOME, "test_data_organization.csv"),
+        (merlin.CODEBOOK_HOME, "test_codebook.csv"),
+        (merlin.CODEBOOK_HOME, "test_codebook2.csv"),
+        (merlin.POSITION_HOME, "test_positions.csv"),
+        (merlin.ANALYSIS_PARAMETERS_HOME, "test_analysis_parameters.json"),
+        (merlin.MICROSCOPE_PARAMETERS_HOME, "test_microscope_parameters.json"),
+    ]
+    for home_folder, filename in to_copy:
+        shutil.copyfile(
+            os.sep.join([root, folder, filename]),
+            os.sep.join([home_folder, filename]),
+        )
+
+
 @pytest.fixture(scope="session")
 def base_files():
     folderList = [
@@ -38,32 +54,7 @@ def base_files():
             shutil.rmtree(folder)
         os.makedirs(folder)
 
-    shutil.copyfile(
-        os.sep.join([root, "auxiliary_files", "test_data_organization.csv"]),
-        os.sep.join([merlin.DATA_ORGANIZATION_HOME, "test_data_organization.csv"]),
-    )
-    shutil.copyfile(
-        os.sep.join([root, "auxiliary_files", "test_codebook.csv"]),
-        os.sep.join([merlin.CODEBOOK_HOME, "test_codebook.csv"]),
-    )
-    shutil.copyfile(
-        os.sep.join([root, "auxiliary_files", "test_codebook2.csv"]),
-        os.sep.join([merlin.CODEBOOK_HOME, "test_codebook2.csv"]),
-    )
-    shutil.copyfile(
-        os.sep.join([root, "auxiliary_files", "test_positions.csv"]),
-        os.sep.join([merlin.POSITION_HOME, "test_positions.csv"]),
-    )
-    shutil.copyfile(
-        os.sep.join([root, "auxiliary_files", "test_analysis_parameters.json"]),
-        os.sep.join([merlin.ANALYSIS_PARAMETERS_HOME, "test_analysis_parameters.json"]),
-    )
-    shutil.copyfile(
-        os.sep.join([root, "auxiliary_files", "test_microscope_parameters.json"]),
-        os.sep.join(
-            [merlin.MICROSCOPE_PARAMETERS_HOME, "test_microscope_parameters.json"]
-        ),
-    )
+    copy_test_files("auxiliary_files")
 
     yield
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,6 +29,7 @@ def copy_test_files(folder):
         (merlin.CODEBOOK_HOME, "test_codebook2.csv"),
         (merlin.POSITION_HOME, "test_positions.csv"),
         (merlin.ANALYSIS_PARAMETERS_HOME, "test_analysis_parameters.json"),
+        (merlin.ANALYSIS_PARAMETERS_HOME, "test_max_project.json"),
         (merlin.MICROSCOPE_PARAMETERS_HOME, "test_microscope_parameters.json"),
     ]
     for home_folder, filename in to_copy:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -77,7 +77,7 @@ def simple_data(base_files):
     shutil.rmtree(dataDirectory)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def simple_merfish_data(merfish_files):
     testMERFISHData = dataset.MERFISHDataSet(
         "merfish_test",
@@ -87,7 +87,10 @@ def simple_merfish_data(merfish_files):
         microscopeParametersName="test_microscope_parameters.json",
     )
     yield testMERFISHData
-    shutil.rmtree("merfish_test")
+    import pdb
+
+    pdb.set_trace()
+    shutil.rmtree(os.path.join(merlin.ANALYSIS_HOME, "merfish_test"))
 
 
 @pytest.fixture(scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ import shutil
 import pytest
 
 import merlin
-from merlin.analysis import testtask
+import test.simple_tasks as simple_tasks
 from merlin.core import dataset
 
 root = os.path.join(os.path.dirname(merlin.__file__), "..", "test")
@@ -125,7 +125,7 @@ def two_codebook_merfish_data(merfish_files):
 
 @pytest.fixture()
 def single_task(simple_data):
-    task = testtask.SimpleAnalysisTask(
+    task = simple_tasks.SimpleAnalysisTask(
         simple_data, parameters={"a": 5, "b": "b_string"}
     )
     yield task
@@ -134,9 +134,9 @@ def single_task(simple_data):
 
 @pytest.fixture(
     params=[
-        testtask.SimpleAnalysisTask,
-        testtask.SimpleParallelAnalysisTask,
-        testtask.SimpleInternallyParallelAnalysisTask,
+        simple_tasks.SimpleAnalysisTask,
+        simple_tasks.SimpleParallelAnalysisTask,
+        simple_tasks.SimpleInternallyParallelAnalysisTask,
     ],
 )
 def simple_task(simple_data, request):
@@ -147,9 +147,9 @@ def simple_task(simple_data, request):
 
 @pytest.fixture(
     params=[
-        testtask.SimpleAnalysisTask,
-        testtask.SimpleParallelAnalysisTask,
-        testtask.SimpleInternallyParallelAnalysisTask,
+        simple_tasks.SimpleAnalysisTask,
+        simple_tasks.SimpleParallelAnalysisTask,
+        simple_tasks.SimpleInternallyParallelAnalysisTask,
     ],
 )
 def simple_merfish_task(simple_merfish_data, request):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -87,9 +87,6 @@ def simple_merfish_data(merfish_files):
         microscopeParametersName="test_microscope_parameters.json",
     )
     yield testMERFISHData
-    import pdb
-
-    pdb.set_trace()
     shutil.rmtree(os.path.join(merlin.ANALYSIS_HOME, "merfish_test"))
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,7 +17,6 @@ merlin.DATA_ORGANIZATION_HOME = os.path.abspath("test_dataorganization")
 merlin.POSITION_HOME = os.path.abspath("test_positions")
 merlin.MICROSCOPE_PARAMETERS_HOME = os.path.abspath("test_microcope_parameters")
 
-
 dataDirectory = os.sep.join([merlin.DATA_HOME, "test"])
 merfishDataDirectory = os.sep.join([merlin.DATA_HOME, "merfish_test"])
 
@@ -54,11 +53,8 @@ def base_files():
         if os.path.exists(folder):
             shutil.rmtree(folder)
         os.makedirs(folder)
-
     copy_test_files("auxiliary_files")
-
     yield
-
     for folder in folderList:
         shutil.rmtree(folder)
 
@@ -66,13 +62,10 @@ def base_files():
 @pytest.fixture(scope="session")
 def merfish_files(base_files):
     os.mkdir(merfishDataDirectory)
-
     for imageFile in glob.iglob(os.sep.join([root, "auxiliary_files", "*.tif"])):
         if os.path.isfile(imageFile):
             shutil.copy(imageFile, merfishDataDirectory)
-
     yield
-
     shutil.rmtree(merfishDataDirectory)
 
 
@@ -80,9 +73,7 @@ def merfish_files(base_files):
 def simple_data(base_files):
     os.mkdir(dataDirectory)
     testData = dataset.DataSet("test")
-
     yield testData
-
     shutil.rmtree(dataDirectory)
 
 
@@ -95,7 +86,8 @@ def simple_merfish_data(merfish_files):
         positionFileName="test_positions.csv",
         microscopeParametersName="test_microscope_parameters.json",
     )
-    return testMERFISHData
+    yield testMERFISHData
+    shutil.rmtree("merfish_test")
 
 
 @pytest.fixture(scope="session")
@@ -111,7 +103,6 @@ def two_codebook_merfish_data(merfish_files):
         microscopeParametersName="test_microscope_parameters.json",
     )
     yield testMERFISHData
-
     shutil.rmtree("test_analysis_two_codebook")
 
 

--- a/test/simple_tasks.py
+++ b/test/simple_tasks.py
@@ -1,8 +1,7 @@
+"""Dummy analysis tasks for running tests."""
 import numpy as np
 
 from merlin.core import analysistask
-
-"""This module contains dummy analysis tasks for running tests"""
 
 
 class SimpleAnalysisTask(analysistask.AnalysisTask):
@@ -49,7 +48,7 @@ class SimpleParallelAnalysisTask(analysistask.ParallelAnalysisTask):
 
 
 class RandomNumberParallelAnalysisTask(analysistask.ParallelAnalysisTask):
-    """A test analysis task that generates random numbers."""
+    """Generates random numbers."""
 
     def __init__(self, dataSet, parameters=None, analysisName=None) -> None:
         super().__init__(dataSet, parameters, analysisName)

--- a/test/test_maxproject.py
+++ b/test/test_maxproject.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+import merlin
+from merlin import merlin as m
+
+
+@pytest.mark.fullrun()
+@pytest.mark.slowtest
+def test_maxproject(simple_merfish_data):
+    with open(
+        os.sep.join([merlin.ANALYSIS_PARAMETERS_HOME, "test_max_project.json"]),
+    ) as f:
+        snakefilePath = m.generate_analysis_tasks_and_snakefile(simple_merfish_data, f)
+        m.run_with_snakemake(simple_merfish_data, snakefilePath, 1)

--- a/test/test_plotting.py
+++ b/test/test_plotting.py
@@ -1,12 +1,12 @@
 import numpy as np
 
+import test.simple_tasks as simple_tasks
 from merlin import plots
-from merlin.analysis import testtask
 from merlin.plots import testplots
 
 
 def test_metadata(simple_merfish_data):
-    randomTask = testtask.RandomNumberParallelAnalysisTask(simple_merfish_data)
+    randomTask = simple_tasks.RandomNumberParallelAnalysisTask(simple_merfish_data)
     randomMetadata = testplots.TestPlotMetadata(randomTask, {"test_task": randomTask})
     assert not randomTask.is_complete()
     assert not randomMetadata.is_complete()
@@ -35,7 +35,7 @@ def test_metadata(simple_merfish_data):
 
 
 def test_plotengine(simple_merfish_data):
-    randomTask = testtask.RandomNumberParallelAnalysisTask(simple_merfish_data)
+    randomTask = simple_tasks.RandomNumberParallelAnalysisTask(simple_merfish_data)
     assert not randomTask.is_complete()
 
     plotEngine = plots.PlotEngine(randomTask, {"test_task": randomTask})

--- a/test/test_snakemake.py
+++ b/test/test_snakemake.py
@@ -26,7 +26,7 @@ def test_snakemake_generator_one_task(simple_merfish_data):
         "analysis_tasks": [
             {
                 "task": "SimpleAnalysisTask",
-                "module": "merlin.analysis.testtask",
+                "module": "test.simple_tasks",
                 "parameters": {},
             }
         ]
@@ -47,19 +47,19 @@ def test_snakemake_generator_task_chain(simple_merfish_data):
         "analysis_tasks": [
             {
                 "task": "SimpleAnalysisTask",
-                "module": "merlin.analysis.testtask",
+                "module": "test.simple_tasks",
                 "analysis_name": "Task1",
                 "parameters": {},
             },
             {
                 "task": "SimpleParallelAnalysisTask",
-                "module": "merlin.analysis.testtask",
+                "module": "test.simple_tasks",
                 "analysis_name": "Task2",
                 "parameters": {"dependencies": ["Task1"]},
             },
             {
                 "task": "SimpleParallelAnalysisTask",
-                "module": "merlin.analysis.testtask",
+                "module": "test.simple_tasks",
                 "analysis_name": "Task3",
                 "parameters": {"dependencies": ["Task2"]},
             },


### PR DESCRIPTION
* Add two tasks `MaxProjectFiducial` and `MaxProjectBits`
  * `MaxProjectFiducial` allows using all z-slices of fiducial beads when available instead of having to select a single z-slice where some fiducial beads may be out of focus.
  * `MaxProjectBits` can simulate a polyT channel from all the available bits for use in `WatershedSegment`
* Update WatershedSegment and FiducialCorrelationWarp to access max projected images from these tasks when they are included in downstream tasks' parameters.

Mixed in are a handful of miscellaneous improvements like
* Move SimpleTasks into the tests folder as they're only used in tests and not part of the public API
* add docstrings and type annotations to modified functions
* Drop a few unused or redundant functions like `get_image_dimensions` and `get_microns_per_pixel`
* Renames some verbose variable names such as `frame_number` --> `frame`